### PR TITLE
skeleton of battle rules

### DIFF
--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
 /// A character unique identifier.
-#[derive(Debug, Clone, PartialEq, Hash, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Hash, Eq, Serialize, Deserialize)]
 pub struct CharacterId(pub String);
 
 impl From<&str> for CharacterId {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod proficiency;
 pub use crate::proficiency::{Proficiency, ProficiencyBonus};
 
 pub mod rules;
+pub use crate::rules::{narrator::Narrator, SRDRules, SRDRulesVersion};
 
 pub mod skill;
 pub use self::skill::SkillId;

--- a/src/rules/actor_rules.rs
+++ b/src/rules/actor_rules.rs
@@ -1,0 +1,66 @@
+//! Implementation of rules for actors.
+
+use crate::rules::narrator::Narrator;
+use crate::rules::SRDRules;
+use std::sync::Arc;
+use weasel::{
+    Action, Actor, ActorRules, BattleState, Entropy, EventQueue, WeaselResult, WriteMetrics,
+};
+
+/// Rules to manage abilities that can be activated and any action a character can take.
+pub struct SRDActorRules<N: Narrator> {
+    #[allow(dead_code)] // TODO remove
+    narrator: Arc<N>,
+}
+
+impl<'a, N: Narrator> SRDActorRules<N> {
+    /// Creates a new instance.
+    pub fn new(narrator: Arc<N>) -> Self {
+        Self { narrator }
+    }
+}
+
+impl<N: Narrator> ActorRules<SRDRules<N>> for SRDActorRules<N> {
+    type Ability = weasel::rules::empty::EmptyAbility; // TODO use a real type
+    type AbilitiesSeed = (); // TODO use a real type
+    type Activation = (); // TODO use a real type
+    type AbilitiesAlteration = (); // TODO use a real type
+
+    fn generate_abilities(
+        &self,
+        _seed: &Option<Self::AbilitiesSeed>,
+        _entropy: &mut Entropy<SRDRules<N>>,
+        _metrics: &mut WriteMetrics<SRDRules<N>>,
+    ) -> Box<dyn Iterator<Item = Self::Ability>> {
+        unimplemented!()
+    }
+
+    fn activable(
+        &self,
+        _state: &BattleState<SRDRules<N>>,
+        _action: Action<SRDRules<N>>,
+    ) -> WeaselResult<(), SRDRules<N>> {
+        unimplemented!()
+    }
+
+    fn activate(
+        &self,
+        _state: &BattleState<SRDRules<N>>,
+        _action: Action<SRDRules<N>>,
+        _event_queue: &mut Option<EventQueue<SRDRules<N>>>,
+        _entropy: &mut Entropy<SRDRules<N>>,
+        _metrics: &mut WriteMetrics<SRDRules<N>>,
+    ) {
+        unimplemented!()
+    }
+
+    fn alter_abilities(
+        &self,
+        _actor: &mut dyn Actor<SRDRules<N>>,
+        _alteration: &Self::AbilitiesAlteration,
+        _entropy: &mut Entropy<SRDRules<N>>,
+        _metrics: &mut WriteMetrics<SRDRules<N>>,
+    ) {
+        unimplemented!()
+    }
+}

--- a/src/rules/character_rules.rs
+++ b/src/rules/character_rules.rs
@@ -1,0 +1,50 @@
+//! Implementation of rules for characters.
+
+use crate::character::CharacterId;
+use crate::rules::narrator::Narrator;
+use crate::rules::SRDRules;
+use std::sync::Arc;
+use weasel::{Character, CharacterRules, Entropy, Transmutation, WriteMetrics};
+
+/// Rules for representing and evolving characters.\
+/// Character in weasel has a broader definition since it includes objects as well.
+pub struct SRDCharacterRules<N: Narrator> {
+    #[allow(dead_code)] // TODO remove
+    narrator: Arc<N>,
+}
+
+impl<N: Narrator> SRDCharacterRules<N> {
+    /// Creates a new instance.
+    pub fn new(narrator: Arc<N>) -> Self {
+        Self { narrator }
+    }
+}
+
+impl<N: Narrator> CharacterRules<SRDRules<N>> for SRDCharacterRules<N> {
+    type CreatureId = CharacterId;
+    type ObjectId = (); // TODO use a real type
+    type Statistic = weasel::rules::empty::EmptyStat; // TODO use a real type
+    type StatisticsSeed = (); // TODO use a real type
+    type StatisticsAlteration = (); // TODO use a real type
+    type Status = weasel::rules::empty::EmptyStatus; // TODO not sure if we need this
+    type StatusesAlteration = (); // TODO not sure if we need this
+
+    fn generate_statistics(
+        &self,
+        _seed: &Option<Self::StatisticsSeed>,
+        _entropy: &mut Entropy<SRDRules<N>>,
+        _metrics: &mut WriteMetrics<SRDRules<N>>,
+    ) -> Box<dyn Iterator<Item = Self::Statistic>> {
+        unimplemented!()
+    }
+
+    fn alter_statistics(
+        &self,
+        _character: &mut dyn Character<SRDRules<N>>,
+        _alteration: &Self::StatisticsAlteration,
+        _entropy: &mut Entropy<SRDRules<N>>,
+        _metrics: &mut WriteMetrics<SRDRules<N>>,
+    ) -> Option<Transmutation> {
+        unimplemented!()
+    }
+}

--- a/src/rules/fight_rules.rs
+++ b/src/rules/fight_rules.rs
@@ -1,0 +1,35 @@
+//! Implementation of rules for combat.
+
+use crate::rules::narrator::Narrator;
+use crate::rules::SRDRules;
+use std::sync::Arc;
+use weasel::{BattleState, Entropy, EventQueue, FightRules, WriteMetrics};
+
+/// Rules to manage combat and damage.
+pub struct SRDFightRules<N: Narrator> {
+    #[allow(dead_code)] // TODO remove
+    narrator: Arc<N>,
+}
+
+impl<N: Narrator> SRDFightRules<N> {
+    /// Creates a new instance.
+    pub fn new(narrator: Arc<N>) -> Self {
+        Self { narrator }
+    }
+}
+
+impl<N: Narrator> FightRules<SRDRules<N>> for SRDFightRules<N> {
+    type Impact = (); // TODO use a real type
+    type Potency = (); // TODO not sure if we need this
+
+    fn apply_impact(
+        &self,
+        _state: &BattleState<SRDRules<N>>,
+        _impact: &Self::Impact,
+        _event_queue: &mut Option<EventQueue<SRDRules<N>>>,
+        _entropy: &mut Entropy<SRDRules<N>>,
+        _metrics: &mut WriteMetrics<SRDRules<N>>,
+    ) {
+        unimplemented!()
+    }
+}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,6 +1,138 @@
 //! weasel's battle rules implementation.
 
-use weasel::{battle_rules, rules::empty::*, BattleRules};
+pub mod actor_rules;
 
-// weasel compatible battle rules implementing the Systems Reference Document (SRD).
-battle_rules! {}
+pub mod character_rules;
+
+pub mod fight_rules;
+
+pub mod narrator;
+
+pub mod rounds_rules;
+
+pub mod space_rules;
+
+pub mod team_rules;
+
+use self::actor_rules::SRDActorRules;
+use self::character_rules::SRDCharacterRules;
+use self::fight_rules::SRDFightRules;
+use self::narrator::Narrator;
+use self::rounds_rules::SRDRoundsRules;
+use self::space_rules::SRDSpaceRules;
+use self::team_rules::SRDTeamRules;
+use crate::compendium::compendium;
+use crate::util::PackageVersion;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use weasel::rules::{empty::EmptyUserRules, entropy::UniformDistribution};
+use weasel::BattleRules;
+
+/// weasel compatible battle rules implementing the Systems Reference Document (SRD).
+pub struct SRDRules<N: Narrator> {
+    narrator: Arc<N>,
+    team_rules: SRDTeamRules<N>,
+    character_rules: SRDCharacterRules<N>,
+    actor_rules: SRDActorRules<N>,
+    fight_rules: SRDFightRules<N>,
+    user_rules: EmptyUserRules,
+    space_rules: Option<SRDSpaceRules<N>>,
+    rounds_rules: Option<SRDRoundsRules<N>>,
+    entropy_rules: UniformDistribution<u8>,
+    version: SRDRulesVersion,
+}
+
+impl<N: Narrator> SRDRules<N> {
+    /// Creates a new instance of these rules.
+    pub fn new(narrator: N) -> Self {
+        let narrator = Arc::new(narrator);
+        Self {
+            narrator: narrator.clone(),
+            team_rules: SRDTeamRules::new(narrator.clone()),
+            character_rules: SRDCharacterRules::new(narrator.clone()),
+            actor_rules: SRDActorRules::new(narrator.clone()),
+            fight_rules: SRDFightRules::new(narrator.clone()),
+            user_rules: EmptyUserRules::default(),
+            space_rules: Some(SRDSpaceRules::new(narrator.clone())),
+            rounds_rules: Some(SRDRoundsRules::new(narrator)),
+            entropy_rules: UniformDistribution::default(),
+            version: SRDRulesVersion::new(compendium().version(), PackageVersion::from_env()),
+        }
+    }
+
+    /// Returns the narrator of the battle.
+    pub fn narrator(&self) -> &N {
+        &self.narrator
+    }
+}
+
+impl<N: Narrator + Default> Default for SRDRules<N> {
+    fn default() -> Self {
+        Self::new(N::default())
+    }
+}
+
+impl<N: Narrator> BattleRules for SRDRules<N> {
+    type TR = SRDTeamRules<N>;
+    type CR = SRDCharacterRules<N>;
+    type AR = SRDActorRules<N>;
+    type FR = SRDFightRules<N>;
+    type UR = EmptyUserRules;
+    type SR = SRDSpaceRules<N>;
+    type RR = SRDRoundsRules<N>;
+    // Uniform distribution of random numbers to roll from a d4 up to a d100.
+    type ER = UniformDistribution<u8>;
+    type Version = SRDRulesVersion;
+
+    fn team_rules(&self) -> &Self::TR {
+        &self.team_rules
+    }
+
+    fn character_rules(&self) -> &Self::CR {
+        &self.character_rules
+    }
+
+    fn actor_rules(&self) -> &Self::AR {
+        &self.actor_rules
+    }
+
+    fn fight_rules(&self) -> &Self::FR {
+        &self.fight_rules
+    }
+
+    fn user_rules(&self) -> &Self::UR {
+        &self.user_rules
+    }
+
+    fn space_rules(&mut self) -> Self::SR {
+        self.space_rules.take().expect("space_rules is None!")
+    }
+
+    fn rounds_rules(&mut self) -> Self::RR {
+        self.rounds_rules.take().expect("rounds_rules is None!")
+    }
+
+    fn entropy_rules(&mut self) -> Self::ER {
+        self.entropy_rules
+    }
+
+    fn version(&self) -> &Self::Version {
+        &self.version
+    }
+}
+
+/// Version of a SRDRules instance.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SRDRulesVersion {
+    compendium: u32,
+    package: PackageVersion,
+}
+
+impl SRDRulesVersion {
+    pub(crate) fn new(compendium: u32, package: PackageVersion) -> Self {
+        SRDRulesVersion {
+            compendium,
+            package,
+        }
+    }
+}

--- a/src/rules/narrator.rs
+++ b/src/rules/narrator.rs
@@ -1,0 +1,16 @@
+//! Smart storytelling module.
+
+/// A narrator tells of all episodes happening during the battle.
+pub trait Narrator: Send + Sync {
+    // TODO fn episode(episode);
+}
+
+/// A narrator that does nothing.
+pub struct NopNarrator {}
+
+impl Narrator for NopNarrator {}
+
+/// A narrator to debug episodes.
+pub struct DebugNarrator {}
+
+impl Narrator for DebugNarrator {}

--- a/src/rules/rounds_rules.rs
+++ b/src/rules/rounds_rules.rs
@@ -1,0 +1,64 @@
+//! Implementation of rules for the order of initiative.
+
+use crate::rules::narrator::Narrator;
+use crate::rules::SRDRules;
+use std::sync::Arc;
+use weasel::{Actor, Entities, Entropy, RoundsRules, Space, WriteMetrics};
+
+/// Rules to determine the order of initiative during a battle.
+pub struct SRDRoundsRules<N: Narrator> {
+    #[allow(dead_code)] // TODO remove
+    narrator: Arc<N>,
+}
+
+impl<N: Narrator> SRDRoundsRules<N> {
+    /// Creates a new instance.
+    pub fn new(narrator: Arc<N>) -> Self {
+        Self { narrator }
+    }
+}
+
+impl<N: Narrator> RoundsRules<SRDRules<N>> for SRDRoundsRules<N> {
+    type RoundsSeed = (); // TODO use a real type
+    type RoundsModel = (); // TODO use a real type
+
+    fn generate_model(&self, _: &Option<Self::RoundsSeed>) -> Self::RoundsModel {
+        unimplemented!()
+    }
+
+    fn eligible(&self, _model: &Self::RoundsModel, _actor: &dyn Actor<SRDRules<N>>) -> bool {
+        unimplemented!()
+    }
+
+    fn on_start(
+        &self,
+        _entities: &Entities<SRDRules<N>>,
+        _space: &Space<SRDRules<N>>,
+        _model: &mut Self::RoundsModel,
+        _actor: &dyn Actor<SRDRules<N>>,
+        _entropy: &mut Entropy<SRDRules<N>>,
+        _metrics: &mut WriteMetrics<SRDRules<N>>,
+    ) {
+        unimplemented!()
+    }
+
+    fn on_actor_added(
+        &self,
+        _model: &mut Self::RoundsModel,
+        _actor: &dyn Actor<SRDRules<N>>,
+        _entropy: &mut Entropy<SRDRules<N>>,
+        _metrics: &mut WriteMetrics<SRDRules<N>>,
+    ) {
+        unimplemented!()
+    }
+
+    fn on_actor_removed(
+        &self,
+        _model: &mut Self::RoundsModel,
+        _actor: &dyn Actor<SRDRules<N>>,
+        _entropy: &mut Entropy<SRDRules<N>>,
+        _metrics: &mut WriteMetrics<SRDRules<N>>,
+    ) {
+        unimplemented!()
+    }
+}

--- a/src/rules/space_rules.rs
+++ b/src/rules/space_rules.rs
@@ -1,0 +1,49 @@
+//! Implementation of rules for movement and positions.
+
+use crate::rules::narrator::Narrator;
+use crate::rules::SRDRules;
+use std::sync::Arc;
+use weasel::{PositionClaim, SpaceRules, WeaselResult, WriteMetrics};
+
+/// Rules for creatures' movement and spatial positions.
+pub struct SRDSpaceRules<N: Narrator> {
+    #[allow(dead_code)] // TODO remove
+    narrator: Arc<N>,
+}
+
+impl<N: Narrator> SRDSpaceRules<N> {
+    /// Creates a new instance.
+    pub fn new(narrator: Arc<N>) -> Self {
+        Self { narrator }
+    }
+}
+
+impl<N: Narrator> SpaceRules<SRDRules<N>> for SRDSpaceRules<N> {
+    type Position = (); // TODO use a real type
+    type SpaceSeed = (); // TODO use a real type
+    type SpaceAlteration = (); // TODO use a real type
+    type SpaceModel = (); // TODO use a real type
+
+    fn generate_model(&self, _: &Option<Self::SpaceSeed>) -> Self::SpaceModel {
+        unimplemented!()
+    }
+
+    fn check_move(
+        &self,
+        _model: &Self::SpaceModel,
+        _claim: PositionClaim<SRDRules<N>>,
+        _position: &Self::Position,
+    ) -> WeaselResult<(), SRDRules<N>> {
+        unimplemented!()
+    }
+
+    fn move_entity(
+        &self,
+        _model: &mut Self::SpaceModel,
+        _claim: PositionClaim<SRDRules<N>>,
+        _position: Option<&Self::Position>,
+        _metrics: &mut WriteMetrics<SRDRules<N>>,
+    ) {
+        unimplemented!()
+    }
+}

--- a/src/rules/team_rules.rs
+++ b/src/rules/team_rules.rs
@@ -1,0 +1,29 @@
+//! Implementation of rules for teams.
+
+use crate::character::CharacterId;
+use crate::rules::narrator::Narrator;
+use crate::rules::SRDRules;
+use std::sync::Arc;
+use weasel::TeamRules;
+
+/// Teams do not exists per se in the SRD, but weasel requires them.\
+/// The easy solution is have a one to one mapping between character and team.
+/// There's no need to implement any specific behavior for teams.
+pub struct SRDTeamRules<N: Narrator> {
+    #[allow(dead_code)] // TODO remove
+    narrator: Arc<N>,
+}
+
+impl<N: Narrator> SRDTeamRules<N> {
+    /// Creates a new instance.
+    pub fn new(narrator: Arc<N>) -> Self {
+        Self { narrator }
+    }
+}
+
+impl<N: Narrator> TeamRules<SRDRules<N>> for SRDTeamRules<N> {
+    // Same as the Id for Characters.
+    type Id = CharacterId;
+    type ObjectivesSeed = ();
+    type Objectives = ();
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,7 +12,6 @@ pub(crate) struct PackageVersion {
 }
 
 impl PackageVersion {
-    #[allow(dead_code)] // TODO remove as soon as this's used
     pub(crate) const fn new(major: u16, minor: u16, patch: u16) -> Self {
         Self {
             major,
@@ -22,7 +21,6 @@ impl PackageVersion {
     }
 
     /// Constructs a new `PackageVersion` from the environmental variables exposed by cargo.
-    #[allow(dead_code)] // TODO remove as soon as this's used
     pub(crate) fn from_env() -> Self {
         let major = VERSION_MAJOR.parse().unwrap();
         let minor = VERSION_MINOR.parse().unwrap();


### PR DESCRIPTION
PR adds a skeleton for the battle rules trait(s).

There's a general trait with wraps everything: `SRDRules`. This trait will be later used to parameterize all events, for instance `ActivateAbility<SRDRules>`, etc.

Insider `SRDRules` there are many other sub-rules so that every aspect of the gameplay can be developed independently.

- `SRDTeamRules`: doesn't do anything special, basically a no-op, but weasel requires teams; maybe will be useful later to put summoned creatures in the same team as the character?
- `SRDCharacterRules`: everything about characters, monsters and objects statistics and abilities.
- `SRDActorRules`: whatever active abilities will do
- `SRDFightRules`: processing hits and damage
- `SRDSpaceRules`: the terrain, positions and movement
- `SRDRoundsRules`: determines the order of initiative
- Entropy: we use a `UniformDistribution<u8>` because is enough to roll up to the d100
- UserRules: no-op, we don't use it at least for now

There's a `SRDRulesVersion` as well, which is the version of the compendium + the package semver. It's used by weasel to perform protect both the client and the server from peers on a more recent or older build.

The PR also add a (for now) empty `Narrator`. It is a trait that the user can implement to process 'episodes' as he wishes. Episodes will be for instance rolling a dice, attempting an attack, etc. Typical application is to create the window where the player can see how unlucky he was with his rolls.